### PR TITLE
Add js test framework to client-side

### DIFF
--- a/client-side/.gitignore
+++ b/client-side/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 npm-debug.log
 package-lock.json
+yarn.lock
+.vscode/*

--- a/client-side/package.json
+++ b/client-side/package.json
@@ -9,11 +9,12 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
+    "jest": "^24.9.0",
     "webpack": "^4.40.2",
     "webpack-cli": "^3.3.9"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "build": "webpack"
   },
   "keywords": [],

--- a/client-side/test/index.test.js
+++ b/client-side/test/index.test.js
@@ -1,0 +1,13 @@
+const { mnemonicToSeedSync } = require("bip39");
+
+describe("Seed Tests", () => {
+  test("should convert mnemonic to seed", () => {
+    const seed = mnemonicToSeedSync(
+      "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+      "BismuthGVP"
+    ).toString("hex");
+    expect(seed).toBe(
+      "95a7ecb56bda5eba808eec2407b418002b824c6c1cb159ec44b8371405629f8429419e98e1b67fc6367368f5d82871a501bbc655a62d31e8391411d7a6e74b86"
+    );
+  });
+});


### PR DESCRIPTION
This includes a sample test (which will ideally be removed in the future and we will add better tests).

The tests can be run using `yarn test` or `npm run test`.